### PR TITLE
Convert block id to integer

### DIFF
--- a/recoverpy/ui/screens/screen_with_block_display.py
+++ b/recoverpy/ui/screens/screen_with_block_display.py
@@ -74,7 +74,7 @@ class MenuWithBlockDisplay(Screen):
 
     def display_next_block(self):
         try:
-            self.display_block(self.current_block + 1)
+            self.display_block(int(self.current_block) + 1)
         except ValueError:
             return
 


### PR DESCRIPTION
Not sure why it's a string in the first place, but I saw that `display_previous_block` already does it.